### PR TITLE
Fix: Self DM message count

### DIFF
--- a/Nostrid.Core/Data/DmService.cs
+++ b/Nostrid.Core/Data/DmService.cs
@@ -89,7 +89,19 @@ public class DmService
         var accountIsL = accountId.CompareTo(otherAccountId) < 0;
 
         var now = DateTime.UtcNow;
-        if (accountIsL)
+
+        if (accountId == otherAccountId)
+        {
+            // you can dm yourself, this fixes the message counts.
+            db.DmPairs
+                .Where(p => p.AccountL == accountId && p.AccountH == otherAccountId)
+                .ExecuteUpdate(p => p.SetProperty(p => p.LastReadL, now));
+
+            db.DmPairs
+                .Where(p => p.AccountH == accountId && p.AccountL == otherAccountId)
+                .ExecuteUpdate(p => p.SetProperty(p => p.LastReadH, now));
+        }
+        else if (accountIsL)
         {
             db.DmPairs
                 .Where(p => p.AccountL == accountId && p.AccountH == otherAccountId)

--- a/README.md
+++ b/README.md
@@ -138,9 +138,13 @@ You can find the binaries in the [Releases](https://github.com/lapulpeta/Nostrid
 2. Clone this repository
 3. Make sure `git` is in your `PATH` system variable
 4. Run `git submodule update` to restore custom libraries
-5. Open solution in Visual Studio and run
-6. For Android: run `dotnet build -c Release -f net7.0-android` in `Nostrid` inner project
-7. For MacOS: run `dotnet publish -c Release -f net7.0-maccatalyst` in `Nostrid` inner project
+5. Ensure in Windows Settings -> Developer Settings -> Developer Mode is ON
+6. Open Solution
+7. From Package Manager Console run -> dotnet workload restore
+8. Build Solution
+9. Set "Nostrid" as startup project -> Run
+10. For Android: run `dotnet build -c Release -f net7.0-android` in `Nostrid` inner project
+11. For MacOS: run `dotnet publish -c Release -f net7.0-maccatalyst` in `Nostrid` inner project
 
 ## Authors
 


### PR DESCRIPTION
For self DM message the counts where not correct as the LastReadL column date was not being set.
In SetLastRead, we test for self DM and set the LastReadL fixing the message count.